### PR TITLE
Overly eager react-devtools 

### DIFF
--- a/packages/react-devtools/bin.js
+++ b/packages/react-devtools/bin.js
@@ -15,8 +15,19 @@ const argv = process.argv.slice(2);
 const pkg = require('./package.json');
 const updateNotifier = require('update-notifier');
 
-// notify if there's an update
-updateNotifier({pkg}).notify({defer: false});
+// Notify if there's an update in 7 days' interval
+const notifier = updateNotifier({
+  pkg,
+  updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
+});
+
+if (notifier.update) {
+  const updateMsg =
+    `Update available ${notifier.update.current} -> ${notifier.update.latest}` +
+    '\nTo update:' +
+    '\n"npm i [-g] react-devtools" or "yarn add react-devtools"';
+  notifier.notify({defer: false, message: updateMsg});
+}
 
 const result = spawn.sync(electron, [require.resolve('./app')].concat(argv), {
   stdio: 'ignore',


### PR DESCRIPTION
Resolving the issue: https://github.com/facebook/react/issues/20061
Change interval of update-notifier to 7 days from the current default of 1 day. Message updated with yarn instruction.